### PR TITLE
Fix issue where aws-export-keys fails on cache lookup

### DIFF
--- a/.aws_functions
+++ b/.aws_functions
@@ -148,7 +148,7 @@ function aws-export-keys() {
   sso_region=$(aws configure get sso_region --profile "$profile")
 
   # find token in cache
-  token_cache_file=$(grep -l \""$sso_start_url"\" "${HOME}/.aws/sso/cache/*")
+  token_cache_file=$(grep -l \""$sso_start_url"\" ${HOME}/.aws/sso/cache/*)
   if [[ -z "$token_cache_file" ]]; then
     # need to login
     echo "you need to aws sso login first"


### PR DESCRIPTION
Fix an issue where running _aws-export-keys_ fails with the error.
`grep: /Users/<username>/.aws/sso/cache/*: No such file or directory`

The root cause is the use of quotes around the filename pattern.